### PR TITLE
Use streaming interface ArduinoJSON

### DIFF
--- a/examples/ESP32_OWM_Current_Forecast_29_epaper_v7/ESP32_OWM_Current_Forecast_29_epaper_v7.ino
+++ b/examples/ESP32_OWM_Current_Forecast_29_epaper_v7/ESP32_OWM_Current_Forecast_29_epaper_v7.ino
@@ -89,7 +89,7 @@ void setup() {
   SetupTime();
   lastConnectionTime = millis();
   bool Received_WxData_OK = false;
-  Received_WxData_OK = (obtain_wx_data("weather") && obtain_wx_data("forecast"));
+  Received_WxData_OK = (obtain_wx_data(client, "weather") && obtain_wx_data(client, "forecast"));
   // Now only refresh the screen if all the data was received OK, otherwise wait until the next timed check otherwise wait until the next timed check
   if (Received_WxData_OK) {
     //Received data OK at this point so turn off the WiFi to save power
@@ -379,40 +379,6 @@ void DisplayWXicon(int x, int y, String IconName, bool LargeSize){
   else if (IconName == "50n")                       if (LargeSize) Fog(x,y-5,Large); else Fog(x,y,Small); 
   else if (IconName == "probrain")                  if (LargeSize) ProbRain(x,y,Large); else ProbRain(x,y,Small);
   else                                              if (LargeSize) Nodata(x,y,Large); else Nodata(x,y,Small);
-}
-//#########################################################################################
-bool obtain_wx_data(String RequestType) {
-  String units = (Units == "M"?"metric":"imperial");
-  client.stop(); // close connection before sending a new request
-  if (client.connect(server, 80)) { // if the connection succeeds
-    // Serial.println("connecting...");
-    // send the HTTP PUT request:
-    if (RequestType == "weather")
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units="+units+"&lang="+Language+" HTTP/1.1");
-    else
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units="+units+"&lang="+Language+"&cnt=6 HTTP/1.1");
-    client.println("Host: api.openweathermap.org");
-    client.println("User-Agent: ESP OWM Receiver/1.1");
-    client.println("Connection: close");
-    client.println();
-    unsigned long timeout = millis();
-    while (client.available() == 0) {
-      if (millis() - timeout > 5000) {
-        Serial.println(">>> Client Timeout !");
-        client.stop();
-        return false;
-      }
-    }
-    if (!DecodeWeather(client, RequestType)) return false;
-    client.stop();
-    return true;
-  }
-  else {
-    // if no connction was made:
-    Serial.println("connection failed");
-    return false;
-  }
-  return true;
 }
 //#########################################################################################
 int StartWiFi(){

--- a/examples/ESP32_OWM_Current_Forecast_29_epaper_v7/ESP32_OWM_Current_Forecast_29_epaper_v7.ino
+++ b/examples/ESP32_OWM_Current_Forecast_29_epaper_v7/ESP32_OWM_Current_Forecast_29_epaper_v7.ino
@@ -63,7 +63,7 @@ bool    Largesize  = true;
 bool    Smallsize  = false;
 #define Large 7
 #define Small 3
-String  time_str, Day_time_str, rxtext; // strings to hold time and received weather data;
+String  time_str, Day_time_str; // strings to hold time and received weather data;
 int     wifisection, displaysection, MoonDay, MoonMonth, MoonYear;
 
 //################ PROGRAM VARIABLES and OBJECTS ##########################################
@@ -382,7 +382,6 @@ void DisplayWXicon(int x, int y, String IconName, bool LargeSize){
 }
 //#########################################################################################
 bool obtain_wx_data(String RequestType) {
-  rxtext = "";
   String units = (Units == "M"?"metric":"imperial");
   client.stop(); // close connection before sending a new request
   if (client.connect(server, 80)) { // if the connection succeeds
@@ -404,34 +403,15 @@ bool obtain_wx_data(String RequestType) {
         return false;
       }
     }
-    char c = 0;
-    bool startJson = false;
-    int jsonend = 0;
-    while (client.available()) {
-      c = client.read();
-      // JSON formats contain an equal number of open and close curly brackets, so check that JSON is received correctly by counting open and close brackets
-      if (c == '{') {
-        startJson = true; // set true to indicate JSON message has started
-        jsonend++;
-      }
-      if (c == '}') { jsonend--; }
-      if (startJson == true) { rxtext += c; } // Add in the received character
-      // if jsonend = 0 then we have have received equal number of curly braces
-      if (jsonend == 0 && startJson == true) {
-        Serial.println("Received OK...");
-        //Serial.println(rxtext);
-        if (!DecodeWeather(rxtext,RequestType)) return false;
-        client.stop();
-        return true;
-      }
-    }
+    if (!DecodeWeather(client, RequestType)) return false;
+    client.stop();
+    return true;
   }
   else {
     // if no connction was made:
     Serial.println("connection failed");
     return false;
   }
-  rxtext = "";
   return true;
 }
 //#########################################################################################

--- a/examples/ESP32_OWM_Current_Forecast_42_epaper_v11/ESP32_OWM_Current_Forecast_42_epaper_v11.ino
+++ b/examples/ESP32_OWM_Current_Forecast_42_epaper_v11/ESP32_OWM_Current_Forecast_42_epaper_v11.ino
@@ -86,7 +86,7 @@ void setup() {
   StartWiFi();
   SetupTime();
   bool Received_WxData_OK = false;
-  Received_WxData_OK = (obtain_wx_data("weather") && obtain_wx_data("forecast"));
+  Received_WxData_OK = (obtain_wx_data(client, "weather") && obtain_wx_data(client, "forecast"));
   // Now only refresh the screen if all the data was received OK, otherwise wait until the next timed check otherwise wait until the next timed check
   if (Received_WxData_OK) {
     StopWiFi(); // Reduces power consumption
@@ -399,40 +399,6 @@ void DisplayWXicon(int x, int y, String IconName, bool LargeSize) {
     else if (IconName == "50d")                       Haze(x, y - 5, LargeSize, IconName);
     else if (IconName == "50n")                       Fog(x, y - 5, LargeSize, IconName);
     else                                              Nodata(x, y, LargeSize);
-}
-//#########################################################################################
-bool obtain_wx_data(String RequestType) {
-  String units = (Units == "M" ? "metric" : "imperial");
-  client.stop(); // close connection before sending a new request
-  if (client.connect(server, 80)) { // if the connection succeeds
-    // Serial.println("connecting...");
-    // send the HTTP PUT request:
-    if (RequestType == "weather")
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + " HTTP/1.0");
-    else
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + "&cnt=24 HTTP/1.0");
-    client.println("Host: api.openweathermap.org");
-    client.println("User-Agent: ESP OWM Receiver/1.1");
-    client.println("Connection: close");
-    client.println();
-    unsigned long timeout = millis();
-    while (client.available() == 0) {
-      if (millis() - timeout > 5000) {
-        Serial.println(F(">>> Client Timeout !"));
-        client.stop();
-        return false;
-      }
-    }
-    if (!DecodeWeather(client, RequestType)) return false;
-    client.stop();
-    return true;
-  }
-  else {
-    // if no connection was made:
-    Serial.println(F("connection failed"));
-    return false;
-  }
-  return true;
 }
 //#########################################################################################
 int StartWiFi() {

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v10/ESP32_OWM_Current_Forecast_75_epaper_v10.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v10/ESP32_OWM_Current_Forecast_75_epaper_v10.ino
@@ -57,7 +57,7 @@ bool LargeIcon =  true;
 bool SmallIcon =  false;
 #define Large  14   // For icon drawing
 #define Small  4    // For icon drawing
-String time_str, date_str, rxtext; // strings to hold time and received weather data;
+String time_str, date_str; // strings to hold time and received weather data;
 int    wifi_signal, wifisection, displaysection, MoonDay, MoonMonth, MoonYear, start_time, wakeup_hour;
 int    Sunrise, Sunset;
 
@@ -440,7 +440,6 @@ void Display_Conditions_Section(int x, int y, String IconName, bool IconSize) {
 }
 //#########################################################################################
 bool obtain_wx_data(String RequestType) {
-  rxtext = "";
   String units = (Units == "M" ? "metric" : "imperial");
   client.stop(); // close connection before sending a new request
   if (client.connect(server, 80)) { // if the connection succeeds
@@ -462,38 +461,15 @@ bool obtain_wx_data(String RequestType) {
         return false;
       }
     }
-    char c = 0;
-    bool startJson = false;
-    int jsonend = 0;
-    while (client.available()) {
-      c = client.read();
-      // JSON formats contain an equal number of open and close curly brackets, so check that JSON is received correctly by counting open and close brackets
-      if (c == '{') {
-        startJson = true; // set true to indicate JSON message has started
-        jsonend++;
-      }
-      if (c == '}') {
-        jsonend--;
-      }
-      if (startJson == true) {
-        rxtext += c;  // Add in the received character
-      }
-      // if jsonend = 0 then we have have received equal number of curly braces
-      if (jsonend == 0 && startJson == true) {
-        Serial.println(F("Received OK..."));
-        //Serial.println(rxtext);
-        if (!DecodeWeather(rxtext, RequestType)) return false;
-        client.stop();
-        return true;
-      }
-    }
+    if (!DecodeWeather(client, RequestType)) return false;
+    client.stop();
+    return true;
   }
   else {
     // if no connection was made:
     Serial.println(F("connection failed"));
     return false;
   }
-  rxtext = "";
   return true;
 }
 //#########################################################################################

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v10/ESP32_OWM_Current_Forecast_75_epaper_v10.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v10/ESP32_OWM_Current_Forecast_75_epaper_v10.ino
@@ -91,7 +91,7 @@ void setup() {
   InitialiseDisplay();
   bool Received_WxData_OK = false;
   if (wakeup_hour >= 8 && wakeup_hour <= 23) {
-    Received_WxData_OK = (obtain_wx_data("weather") && obtain_wx_data("forecast"));
+    Received_WxData_OK = (obtain_wx_data(client, "weather") && obtain_wx_data(client, "forecast"));
   }
   // Now only refresh the screen if all the data was received OK, otherwise wait until the next timed check otherwise wait until the next timed check
   if (Received_WxData_OK) {
@@ -437,40 +437,6 @@ void Display_Conditions_Section(int x, int y, String IconName, bool IconSize) {
   else if (IconName == "50d")                       Haze(x, y, IconSize, IconName);
   else if (IconName == "50n")                       Fog(x, y, IconSize, IconName);
   else                                              Nodata(x, y, IconSize);
-}
-//#########################################################################################
-bool obtain_wx_data(String RequestType) {
-  String units = (Units == "M" ? "metric" : "imperial");
-  client.stop(); // close connection before sending a new request
-  if (client.connect(server, 80)) { // if the connection succeeds
-    // Serial.println("connecting...");
-    // send the HTTP PUT request:
-    if (RequestType == "weather")
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + " HTTP/1.0");
-    else
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + "&cnt=24 HTTP/1.0");
-    client.println("Host: api.openweathermap.org");
-    client.println("User-Agent: ESP OWM Receiver/1.1");
-    client.println("Connection: close");
-    client.println();
-    unsigned long timeout = millis();
-    while (client.available() == 0) {
-      if (millis() - timeout > 5000) {
-        Serial.println(F(">>> Client Timeout !"));
-        client.stop();
-        return false;
-      }
-    }
-    if (!DecodeWeather(client, RequestType)) return false;
-    client.stop();
-    return true;
-  }
-  else {
-    // if no connection was made:
-    Serial.println(F("connection failed"));
-    return false;
-  }
-  return true;
 }
 //#########################################################################################
 int StartWiFi() {

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v10a/ESP32_OWM_Current_Forecast_75_epaper_v10a.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v10a/ESP32_OWM_Current_Forecast_75_epaper_v10a.ino
@@ -58,7 +58,7 @@ bool LargeIcon =  true;
 bool SmallIcon =  false;
 #define Large  14   // For icon drawing
 #define Small  4    // For icon drawing
-String time_str, date_str, rxtext; // strings to hold time and received weather data;
+String time_str, date_str; // strings to hold time and received weather data;
 int    wifi_signal, wifisection, displaysection, MoonDay, MoonMonth, MoonYear, start_time, wakeup_hour;
 int    Sunrise, Sunset;
 
@@ -442,7 +442,6 @@ void Display_Conditions_Section(int x, int y, String IconName, bool IconSize) {
 }
 //#########################################################################################
 bool obtain_wx_data(String RequestType) {
-  rxtext = "";
   String units = (Units == "M" ? "metric" : "imperial");
   client.stop(); // close connection before sending a new request
   if (client.connect(server, 80)) { // if the connection succeeds
@@ -464,38 +463,15 @@ bool obtain_wx_data(String RequestType) {
         return false;
       }
     }
-    char c = 0;
-    bool startJson = false;
-    int jsonend = 0;
-    while (client.available()) {
-      c = client.read();
-      // JSON formats contain an equal number of open and close curly brackets, so check that JSON is received correctly by counting open and close brackets
-      if (c == '{') {
-        startJson = true; // set true to indicate JSON message has started
-        jsonend++;
-      }
-      if (c == '}') {
-        jsonend--;
-      }
-      if (startJson == true) {
-        rxtext += c;  // Add in the received character
-      }
-      // if jsonend = 0 then we have have received equal number of curly braces
-      if (jsonend == 0 && startJson == true) {
-        Serial.println(F("Received OK..."));
-        //Serial.println(rxtext);
-        if (!DecodeWeather(rxtext, RequestType)) return false;
-        client.stop();
-        return true;
-      }
-    }
+    if (!DecodeWeather(client, RequestType)) return false;
+    client.stop();
+    return true;
   }
   else {
     // if no connection was made:
     Serial.println(F("connection failed"));
     return false;
   }
-  rxtext = "";
   return true;
 }
 //#########################################################################################

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v10a/ESP32_OWM_Current_Forecast_75_epaper_v10a.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v10a/ESP32_OWM_Current_Forecast_75_epaper_v10a.ino
@@ -93,7 +93,7 @@ void setup() {
   InitialiseDisplay();
   bool Received_WxData_OK = false;
   if (wakeup_hour >= 8 && wakeup_hour <= 23) {
-    Received_WxData_OK = (obtain_wx_data("weather") && obtain_wx_data("forecast"));
+    Received_WxData_OK = (obtain_wx_data(client, "weather") && obtain_wx_data(client, "forecast"));
   }
   // Now only refresh the screen if all the data was received OK, otherwise wait until the next timed check otherwise wait until the next timed check
   if (Received_WxData_OK) {
@@ -439,40 +439,6 @@ void Display_Conditions_Section(int x, int y, String IconName, bool IconSize) {
   else if (IconName == "50d")                       Haze(x, y, IconSize, IconName);
   else if (IconName == "50n")                       Fog(x, y, IconSize, IconName);
   else                                              Nodata(x, y, IconSize);
-}
-//#########################################################################################
-bool obtain_wx_data(String RequestType) {
-  String units = (Units == "M" ? "metric" : "imperial");
-  client.stop(); // close connection before sending a new request
-  if (client.connect(server, 80)) { // if the connection succeeds
-    // Serial.println("connecting...");
-    // send the HTTP PUT request:
-    if (RequestType == "weather")
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + " HTTP/1.0");
-    else
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + "&cnt=24 HTTP/1.0");
-    client.println("Host: api.openweathermap.org");
-    client.println("User-Agent: ESP OWM Receiver/1.1");
-    client.println("Connection: close");
-    client.println();
-    unsigned long timeout = millis();
-    while (client.available() == 0) {
-      if (millis() - timeout > 5000) {
-        Serial.println(F(">>> Client Timeout !"));
-        client.stop();
-        return false;
-      }
-    }
-    if (!DecodeWeather(client, RequestType)) return false;
-    client.stop();
-    return true;
-  }
-  else {
-    // if no connection was made:
-    Serial.println(F("connection failed"));
-    return false;
-  }
-  return true;
 }
 //#########################################################################################
 int StartWiFi() {

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v11/ESP32_OWM_Current_Forecast_75_epaper_v11.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v11/ESP32_OWM_Current_Forecast_75_epaper_v11.ino
@@ -58,7 +58,7 @@ bool LargeIcon =  true;
 bool SmallIcon =  false;
 #define Large  14   // For icon drawing
 #define Small  4    // For icon drawing
-String time_str, date_str, rxtext; // strings to hold time and received weather data;
+String time_str, date_str; // strings to hold time and received weather data;
 int    wifi_signal, wifisection, displaysection, MoonDay, MoonMonth, MoonYear, start_time, wakeup_hour;
 int    Sunrise, Sunset;
 
@@ -446,7 +446,6 @@ void DisplayConditionsSection(int x, int y, String IconName, bool IconSize) {
 }
 //#########################################################################################
 bool obtain_wx_data(String RequestType) {
-  rxtext = "";
   String units = (Units == "M" ? "metric" : "imperial");
   client.stop(); // close connection before sending a new request
   if (client.connect(server, 80)) { // if the connection succeeds
@@ -468,38 +467,15 @@ bool obtain_wx_data(String RequestType) {
         return false;
       }
     }
-    char c = 0;
-    bool startJson = false;
-    int jsonend = 0;
-    while (client.available()) {
-      c = client.read();
-      // JSON formats contain an equal number of open and close curly brackets, so check that JSON is received correctly by counting open and close brackets
-      if (c == '{') {
-        startJson = true; // set true to indicate JSON message has started
-        jsonend++;
-      }
-      if (c == '}') {
-        jsonend--;
-      }
-      if (startJson == true) {
-        rxtext += c;  // Add in the received character
-      }
-      // if jsonend = 0 then we have have received equal number of curly braces
-      if (jsonend == 0 && startJson == true) {
-        Serial.println(F("Received OK..."));
-        //Serial.println(rxtext);
-        if (!DecodeWeather(rxtext, RequestType)) return false;
-        client.stop();
-        return true;
-      }
-    }
+    if (!DecodeWeather(client, RequestType)) return false;
+    client.stop();
+    return true;
   }
   else {
     // if no connection was made:
     Serial.println(F("connection failed"));
     return false;
   }
-  rxtext = "";
   return true;
 }
 //#########################################################################################

--- a/examples/ESP32_OWM_Current_Forecast_75_epaper_v11/ESP32_OWM_Current_Forecast_75_epaper_v11.ino
+++ b/examples/ESP32_OWM_Current_Forecast_75_epaper_v11/ESP32_OWM_Current_Forecast_75_epaper_v11.ino
@@ -94,7 +94,7 @@ void setup() {
   InitialiseDisplay();
   bool Received_WxData_OK = false;
   if (wakeup_hour >= 8 && wakeup_hour <= 23) {
-    Received_WxData_OK = (obtain_wx_data("weather") && obtain_wx_data("forecast"));
+    Received_WxData_OK = (obtain_wx_data(client, "weather") && obtain_wx_data(client, "forecast"));
   }
   // Now only refresh the screen if all the data was received OK, otherwise wait until the next timed check otherwise wait until the next timed check
   if (Received_WxData_OK) {
@@ -443,40 +443,6 @@ void DisplayConditionsSection(int x, int y, String IconName, bool IconSize) {
   else if (IconName == "50d")                       Haze(x, y, IconSize, IconName);
   else if (IconName == "50n")                       Fog(x, y, IconSize, IconName);
   else                                              Nodata(x, y, IconSize);
-}
-//#########################################################################################
-bool obtain_wx_data(String RequestType) {
-  String units = (Units == "M" ? "metric" : "imperial");
-  client.stop(); // close connection before sending a new request
-  if (client.connect(server, 80)) { // if the connection succeeds
-    // Serial.println("connecting...");
-    // send the HTTP PUT request:
-    if (RequestType == "weather")
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + " HTTP/1.0");
-    else
-      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + "&cnt=24 HTTP/1.0");
-    client.println("Host: api.openweathermap.org");
-    client.println("User-Agent: ESP OWM Receiver/1.1");
-    client.println("Connection: close");
-    client.println();
-    unsigned long timeout = millis();
-    while (client.available() == 0) {
-      if (millis() - timeout > 5000) {
-        Serial.println(F(">>> Client Timeout !"));
-        client.stop();
-        return false;
-      }
-    }
-    if (!DecodeWeather(client, RequestType)) return false;
-    client.stop();
-    return true;
-  }
-  else {
-    // if no connection was made:
-    Serial.println(F("connection failed"));
-    return false;
-  }
-  return true;
 }
 //#########################################################################################
 int StartWiFi() {

--- a/src/common.h
+++ b/src/common.h
@@ -126,20 +126,6 @@ String ConvertUnixTime(int unix_time) {
   return time_str;
 }
 //#########################################################################################
-int JulianDate(int d, int m, int y) {
-  int mm, yy, k1, k2, k3, j;
-  yy = y - (int)((12 - m) / 10);
-  mm = m + 9;
-  if (mm >= 12) mm = mm - 12;
-  k1 = (int)(365.25 * (yy + 4712));
-  k2 = (int)(30.6001 * mm + 0.5);
-  k3 = (int)((int)((yy / 100) + 49) * 0.75) - 38;
-  // 'j' for dates in Julian calendar:
-  j = k1 + k2 + d + 59 + 1;
-  if (j > 2299160) j = j - k3; // 'j' is the Julian date at 12h UT (Universal Time) For Gregorian calendar:
-  return j;
-}
-//#########################################################################################
 float SumOfPrecip(float DataArray[], int readings) {
   float sum = 0;
   for (int i = 0; i <= readings; i++) {

--- a/src/common.h
+++ b/src/common.h
@@ -124,4 +124,39 @@ String ConvertUnixTime(int unix_time) {
   //Serial.println(time_str);
   return time_str;
 }
+
+//#########################################################################################
+bool obtain_wx_data(WiFiClient& client, String RequestType) {
+  String units = (Units == "M" ? "metric" : "imperial");
+  client.stop(); // close connection before sending a new request
+  if (client.connect(server, 80)) { // if the connection succeeds
+    // Serial.println("connecting...");
+    // send the HTTP PUT request:
+    if (RequestType == "weather")
+      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + " HTTP/1.0");
+    else
+      client.println("GET /data/2.5/" + RequestType + "?q=" + City + "," + Country + "&APPID=" + apikey + "&mode=json&units=" + units + "&lang=" + Language + "&cnt=24 HTTP/1.0");
+    client.println("Host: api.openweathermap.org");
+    client.println("User-Agent: ESP OWM Receiver/1.1");
+    client.println("Connection: close");
+    client.println();
+    unsigned long timeout = millis();
+    while (client.available() == 0) {
+      if (millis() - timeout > 5000) {
+        Serial.println(F(">>> Client Timeout !"));
+        client.stop();
+        return false;
+      }
+    }
+    if (!DecodeWeather(client, RequestType)) return false;
+    client.stop();
+    return true;
+  }
+  else {
+    // if no connection was made:
+    Serial.println(F("connection failed"));
+    return false;
+  }
+  return true;
+}
 #endif /* ifndef COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -16,8 +16,7 @@ void Convert_Readings_to_Imperial() {
 
 //#########################################################################################
 // Problems with stucturing JSON decodes, see here: https://arduinojson.org/assistant/
-bool DecodeWeather(String json, String Type) {
-  Serial.println("Received a JSON string of size : " + String(json.length()));
+bool DecodeWeather(WiFiClient& json, String Type) {
   Serial.print(F("Creating object...and "));
   // allocate the JsonDocument
   DynamicJsonDocument doc(20 * 1024);

--- a/src/common.h
+++ b/src/common.h
@@ -125,12 +125,4 @@ String ConvertUnixTime(int unix_time) {
   //Serial.println(time_str);
   return time_str;
 }
-//#########################################################################################
-float SumOfPrecip(float DataArray[], int readings) {
-  float sum = 0;
-  for (int i = 0; i <= readings; i++) {
-    sum += DataArray[i];
-  }
-  return sum;
-}
 #endif /* ifndef COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -5,12 +5,13 @@
 #include <ArduinoJson.h>
 
 #include "forecast_record.h"
+#include "common_functions.h"
 
 //#########################################################################################
 void Convert_Readings_to_Imperial() {
-  WxConditions[0].Pressure = WxConditions[0].Pressure * 0.02953;   // hPa to ins
-  WxForecast[1].Rainfall   = WxForecast[1].Rainfall   * 0.0393701; // mm to inches of rainfall
-  WxForecast[1].Snowfall   = WxForecast[1].Snowfall   * 0.0393701; // mm to inches of snowfall
+  WxConditions[0].Pressure = hPa_to_inHg(WxConditions[0].Pressure);
+  WxForecast[1].Rainfall   = mm_to_inches(WxForecast[1].Rainfall);
+  WxForecast[1].Snowfall   = mm_to_inches(WxForecast[1].Snowfall);
 }
 
 //#########################################################################################

--- a/src/common.h
+++ b/src/common.h
@@ -73,7 +73,7 @@ bool DecodeWeather(WiFiClient& json, String Type) {
       WxForecast[r].Forecast0         = list[r]["weather"][2]["main"].as<char*>();        Serial.println(WxForecast[r].Forecast2);
       WxForecast[r].Description       = list[r]["weather"][0]["description"].as<char*>(); Serial.println(WxForecast[r].Description);
       WxForecast[r].Icon              = list[r]["weather"][0]["icon"].as<char*>();        Serial.println(WxForecast[r].Icon);
-      WxForecast[r].Cloudcover        = list[r]["clouds"]["all"].as<int>();               Serial.println(WxForecast[0].Cloudcover); // in % of cloud cover
+      WxForecast[r].Cloudcover        = list[r]["clouds"]["all"].as<int>();               Serial.println(WxForecast[r].Cloudcover); // in % of cloud cover
       WxForecast[r].Windspeed         = list[r]["wind"]["speed"].as<float>();             Serial.println(WxForecast[r].Windspeed);
       WxForecast[r].Winddir           = list[r]["wind"]["deg"].as<float>();               Serial.println(WxForecast[r].Winddir);
       WxForecast[r].Rainfall          = list[r]["rain"]["3h"].as<float>();                Serial.println(WxForecast[r].Rainfall);

--- a/src/common_functions.cpp
+++ b/src/common_functions.cpp
@@ -22,3 +22,11 @@ int JulianDate(int d, int m, int y) {
   if (j > 2299160) j = j - k3; // 'j' is the Julian date at 12h UT (Universal Time) For Gregorian calendar:
   return j;
 }
+
+float SumOfPrecip(float DataArray[], int readings) {
+  float sum = 0;
+  for (int i = 0; i <= readings; i++) {
+    sum += DataArray[i];
+  }
+  return sum;
+}

--- a/src/common_functions.cpp
+++ b/src/common_functions.cpp
@@ -1,0 +1,10 @@
+#include "common_functions.h"
+float mm_to_inches(float value_mm)
+{
+  return 0.0393701 * value_mm;
+}
+
+float hPa_to_inHg(float value_hPa)
+{
+  return 0.02953 * value_hPa;
+}

--- a/src/common_functions.cpp
+++ b/src/common_functions.cpp
@@ -8,3 +8,17 @@ float hPa_to_inHg(float value_hPa)
 {
   return 0.02953 * value_hPa;
 }
+
+int JulianDate(int d, int m, int y) {
+  int mm, yy, k1, k2, k3, j;
+  yy = y - (int)((12 - m) / 10);
+  mm = m + 9;
+  if (mm >= 12) mm = mm - 12;
+  k1 = (int)(365.25 * (yy + 4712));
+  k2 = (int)(30.6001 * mm + 0.5);
+  k3 = (int)((int)((yy / 100) + 49) * 0.75) - 38;
+  // 'j' for dates in Julian calendar:
+  j = k1 + k2 + d + 59 + 1;
+  if (j > 2299160) j = j - k3; // 'j' is the Julian date at 12h UT (Universal Time) For Gregorian calendar:
+  return j;
+}

--- a/src/common_functions.h
+++ b/src/common_functions.h
@@ -1,5 +1,9 @@
 #ifndef COMMON_FUNCTIONS_H_
 #define COMMON_FUNCTIONS_H_
+#include <Arduino.h>
+
 float mm_to_inches(float value_mm);
 float hPa_to_inHg(float value_hPa);
+int JulianDate(int d, int m, int y);
+
 #endif /* ifndef COMMON_FUNCTIONS_H_ */

--- a/src/common_functions.h
+++ b/src/common_functions.h
@@ -5,5 +5,6 @@
 float mm_to_inches(float value_mm);
 float hPa_to_inHg(float value_hPa);
 int JulianDate(int d, int m, int y);
+float SumOfPrecip(float DataArray[], int readings);
 
 #endif /* ifndef COMMON_FUNCTIONS_H_ */

--- a/src/common_functions.h
+++ b/src/common_functions.h
@@ -1,0 +1,5 @@
+#ifndef COMMON_FUNCTIONS_H_
+#define COMMON_FUNCTIONS_H_
+float mm_to_inches(float value_mm);
+float hPa_to_inHg(float value_hPa);
+#endif /* ifndef COMMON_FUNCTIONS_H_ */


### PR DESCRIPTION
This is a rather big move of functions towards the common part. But the more interesting part is the use of the streaming interface of ArduinoJSON.
You have mentioned the use of the streaming interface of ArduinoJSON before, but from what I have understood is that a String has been passed to the [deserializejson](https://arduinojson.org/v6/api/json/deserializejson/) function. This basically means that the String was a constant buffer during deserialization. To take full advantage of ArduinoJSON now the Stream from the WiFiClient is passed to directly to the deserialize function (WiFiClient implements the abstract Stream base class). This makes the (additional) copy of the JSON-data unnecessary, avoids the global variable "rxtext", and it saves a few lines on code.
After this streaming interface commit the whole function is moved to common part (updating also the 4.2" version) - unfortunately, it still resides in the header as it uses depends on the decode function which uses global variables; I will fix this later.