### PR TITLE
Moon Phases improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the software to your Arduino's library directory.
 1. From the examples, choose depending on your module either
    - Waveshare_2_9
    - Waveshare_4_2
-   - Waveshare_7_5 (instead of Mini Grafx requires [GxEPD2 library](https://github.com/ZinggJM/GxEPD2), which needs [Adafruit_GFX](https://github.com/adafruit/Adafruit-GFX-Library))
+   - Waveshare_7_5 (instead of Mini Grafx requires [GxEPD2 library](https://github.com/ZinggJM/GxEPD2), which needs [Adafruit_GFX](https://github.com/adafruit/Adafruit-GFX-Library), additionally requires U8g2_for_Adafruit_GFX)
 
 2. Obtain your [OWM API key](https://openweathermap.org/appid) - it's free
 

--- a/examples/Waveshare_2_9/Waveshare_2_9.ino
+++ b/examples/Waveshare_2_9/Waveshare_2_9.ino
@@ -179,27 +179,18 @@ void Draw_Astronomy_Section(){
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
-  int diameter = 38;
-  float Xpos, Ypos, Rpos, Xpos1, Xpos2;
-  gfx.setColor(EPD_BLACK);
-  for (Ypos = 0; Ypos <= 45; Ypos++) {
-    Xpos = sqrt(45 * 45 - Ypos * Ypos);
+  const int diameter = 38;
+  double Phase = NormalizedMoonPhase(dd, mm, yy);
+  if (hemisphere == "south") Phase = 1 - Phase;
     // Draw dark part of moon
-    double pB1x = (90   - Xpos) / 90 * diameter + x;
-    double pB1y = (Ypos + 90) / 90   * diameter + y;
-    double pB2x = (Xpos + 90) / 90   * diameter + x;
-    double pB2y = (Ypos + 90) / 90   * diameter + y;
-    double pB3x = (90   - Xpos) / 90 * diameter + x;
-    double pB3y = (90   - Ypos) / 90 * diameter + y;
-    double pB4x = (Xpos + 90) / 90   * diameter + x;
-    double pB4y = (90   - Ypos) / 90 * diameter + y;
     gfx.setColor(EPD_BLACK);
-    gfx.drawLine(pB1x, pB1y, pB2x, pB2y);
-    gfx.drawLine(pB3x, pB3y, pB4x, pB4y);
+  gfx.fillCircle(x + diameter - 1, y + diameter, diameter / 2 + 1);
+  const int number_of_lines = 90;
+  for (double Ypos = 0; Ypos <= 45; Ypos++) {
+    double Xpos = sqrt(45 * 45 - Ypos * Ypos);
     // Determine the edges of the lighted part of the moon
-    double Phase = NormalizedMoonPhase(dd, mm, yy);
-    if (hemisphere == "south") Phase = 1 - Phase;
-    Rpos = 2 * Xpos;
+    double Rpos = 2 * Xpos;
+    double Xpos1, Xpos2;
     if (Phase < 0.5) {
       Xpos1 = - Xpos;
       Xpos2 = (Rpos - 2 * Phase * Rpos - Xpos);
@@ -209,14 +200,14 @@ void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
       Xpos2 = (Xpos - 2 * Phase * Rpos + Rpos);
     }
     // Draw light part of moon
-    double pW1x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW1y = (90 - Ypos) / 90  * diameter + y;
-    double pW2x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW2y = (90 - Ypos) / 90  * diameter + y;
-    double pW3x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW3y = (Ypos + 90) / 90  * diameter + y;
-    double pW4x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW4y = (Ypos + 90) / 90  * diameter + y;
+    double pW1x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW1y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW2x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW2y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW3x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW3y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
+    double pW4x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW4y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
     gfx.setColor(EPD_WHITE);
     gfx.drawLine(pW1x, pW1y, pW2x, pW2y);
     gfx.drawLine(pW3x, pW3y, pW4x, pW4y);

--- a/examples/Waveshare_2_9/Waveshare_2_9.ino
+++ b/examples/Waveshare_2_9/Waveshare_2_9.ino
@@ -64,7 +64,7 @@ bool    Smallsize  = false;
 #define Large 7
 #define Small 3
 String  time_str, Day_time_str; // strings to hold time and received weather data;
-int     wifisection, displaysection, MoonDay, MoonMonth, MoonYear;
+int     wifisection, displaysection;
 
 //################ PROGRAM VARIABLES and OBJECTS ##########################################
 #define max_readings 6
@@ -173,9 +173,14 @@ void Draw_3hr_Forecast(int x, int y, int index){
 void Draw_Astronomy_Section(){
   gfx.drawString(152,76,"Sun Rise: " + ConvertUnixTime(WxConditions[0].Sunrise).substring(0,5));
   gfx.drawString(178,88,"Set: "      + ConvertUnixTime(WxConditions[0].Sunset).substring(0,5));
-  DrawMoon(230,65,MoonDay,MoonMonth,MoonYear,Hemisphere);
+  time_t now = time(NULL);
+  struct tm * now_utc  = gmtime(&now);
+  const int day_utc = now_utc->tm_mday;
+  const int month_utc = now_utc->tm_mon + 1;
+  const int year_utc = now_utc->tm_year + 1900;
+  DrawMoon(230,65,day_utc, month_utc, year_utc,Hemisphere);
   gfx.drawString(152,100,"Moon phase:");
-  gfx.drawString(152,112,MoonPhase(MoonDay,MoonMonth,MoonYear));
+  gfx.drawString(152,112,MoonPhase(day_utc, month_utc, year_utc));
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {

--- a/examples/Waveshare_4_2/Waveshare_4_2.ino
+++ b/examples/Waveshare_4_2/Waveshare_4_2.ino
@@ -271,27 +271,18 @@ void Draw_Astronomy_Section(int x, int y) {
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
-  int diameter = 38;
-  float Xpos, Ypos, Rpos, Xpos1, Xpos2;
-  gfx.setColor(EPD_BLACK);
-  for (Ypos = 0; Ypos <= 45; Ypos++) {
-    Xpos = sqrt(45 * 45 - Ypos * Ypos);
+  const int diameter = 38;
+  double Phase = NormalizedMoonPhase(dd, mm, yy);
+  if (hemisphere == "south") Phase = 1 - Phase;
     // Draw dark part of moon
-    double pB1x = (90   - Xpos) / 90 * diameter + x;
-    double pB1y = (Ypos + 90) / 90   * diameter + y;
-    double pB2x = (Xpos + 90) / 90   * diameter + x;
-    double pB2y = (Ypos + 90) / 90   * diameter + y;
-    double pB3x = (90   - Xpos) / 90 * diameter + x;
-    double pB3y = (90   - Ypos) / 90 * diameter + y;
-    double pB4x = (Xpos + 90) / 90   * diameter + x;
-    double pB4y = (90   - Ypos) / 90 * diameter + y;
     gfx.setColor(EPD_BLACK);
-    gfx.drawLine(pB1x, pB1y, pB2x, pB2y);
-    gfx.drawLine(pB3x, pB3y, pB4x, pB4y);
+  gfx.fillCircle(x + diameter - 1, y + diameter, diameter / 2 + 1);
+  const int number_of_lines = 90;
+  for (double Ypos = 0; Ypos <= 45; Ypos++) {
+    double Xpos = sqrt(45 * 45 - Ypos * Ypos);
     // Determine the edges of the lighted part of the moon
-    double Phase = NormalizedMoonPhase(dd, mm, yy);
-    if (hemisphere == "south") Phase = 1 - Phase;
-    Rpos = 2 * Xpos;
+    double Rpos = 2 * Xpos;
+    double Xpos1, Xpos2;
     if (Phase < 0.5) {
       Xpos1 = - Xpos;
       Xpos2 = (Rpos - 2 * Phase * Rpos - Xpos);
@@ -301,14 +292,14 @@ void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
       Xpos2 = (Xpos - 2 * Phase * Rpos + Rpos);
     }
     // Draw light part of moon
-    double pW1x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW1y = (90 - Ypos) / 90  * diameter + y;
-    double pW2x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW2y = (90 - Ypos) / 90  * diameter + y;
-    double pW3x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW3y = (Ypos + 90) / 90  * diameter + y;
-    double pW4x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW4y = (Ypos + 90) / 90  * diameter + y;
+    double pW1x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW1y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW2x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW2y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW3x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW3y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
+    double pW4x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW4y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
     gfx.setColor(EPD_WHITE);
     gfx.drawLine(pW1x, pW1y, pW2x, pW2y);
     gfx.drawLine(pW3x, pW3y, pW4x, pW4y);

--- a/examples/Waveshare_4_2/Waveshare_4_2.ino
+++ b/examples/Waveshare_4_2/Waveshare_4_2.ino
@@ -58,7 +58,7 @@ bool SmallIcon   =  false;
 #define Large  10
 #define Small  4
 String time_str, Day_time_str, rxtext; // strings to hold time and received weather data;
-int    wifisection, displaysection, MoonDay, MoonMonth, MoonYear;
+int    wifisection, displaysection;
 int    Sunrise, Sunset;
 
 //################ PROGRAM VARIABLES and OBJECTS ################
@@ -266,8 +266,13 @@ void Draw_Astronomy_Section(int x, int y) {
   gfx.drawString(x + 20, y + 75, ConvertUnixTime(Sunrise).substring(0, 5));
   gfx.drawString(x + 20, y + 86, ConvertUnixTime(Sunset).substring(0, 5));
   gfx.drawString(x + 4, y + 100, "Moon:");
-  gfx.drawString(x + 35, y + 100, MoonPhase(MoonDay, MoonMonth, MoonYear));
-  DrawMoon(x + 103, y + 51, MoonDay, MoonMonth, MoonYear, Hemisphere);
+  time_t now = time(NULL);
+  struct tm * now_utc  = gmtime(&now);
+  const int day_utc = now_utc->tm_mday;
+  const int month_utc = now_utc->tm_mon + 1;
+  const int year_utc = now_utc->tm_year + 1900;
+  gfx.drawString(x + 35, y + 100, MoonPhase(day_utc, month_utc, year_utc));
+  DrawMoon(x + 103, y + 51, day_utc, month_utc, year_utc, Hemisphere);
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {

--- a/examples/Waveshare_7_5/Waveshare_7_5.ino
+++ b/examples/Waveshare_7_5/Waveshare_7_5.ino
@@ -66,7 +66,7 @@ boolean LargeIcon     = true, SmallIcon = false, RxWeather = false, RxForecast =
 #define Large  14          // For icon drawing
 #define Small  4           // For icon drawing
 String  time_str, date_str; // strings to hold time and received weather data;wi
-int     wifi_signal, MoonDay, MoonMonth, MoonYear, StartTime, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0;
+int     wifi_signal, StartTime, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0;
 int     Sunrise, Sunset;
 
 //################ PROGRAM VARIABLES and OBJECTS ################
@@ -335,8 +335,13 @@ void DisplayAstronomySection(int x, int y) {
   u8g2Fonts.setFont(u8g2_font_helvB10_tf);
   drawString(x + 3, y + 19, ConvertUnixTime(WxConditions[0].Sunrise).substring(0, 5) + " " + TXT_SUNRISE, LEFT);
   drawString(x + 3, y + 33, ConvertUnixTime(WxConditions[0].Sunset).substring(0, 5)  + " " + TXT_SUNSET, LEFT);
-  drawString(x + 3, y + 52, MoonPhase(MoonDay, MoonMonth, MoonYear, Hemisphere), LEFT);
-  DrawMoon(x + 110, y, MoonDay, MoonMonth, MoonYear, Hemisphere);
+  time_t now = time(NULL);
+  struct tm * now_utc  = gmtime(&now);
+  const int day_utc = now_utc->tm_mday;
+  const int month_utc = now_utc->tm_mon + 1;
+  const int year_utc = now_utc->tm_year + 1900;
+  drawString(x + 3, y + 52, MoonPhase(day_utc, month_utc, year_utc, Hemisphere), LEFT);
+  DrawMoon(x + 110, y, day_utc, month_utc, year_utc, Hemisphere);
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {

--- a/examples/Waveshare_7_5/Waveshare_7_5.ino
+++ b/examples/Waveshare_7_5/Waveshare_7_5.ino
@@ -340,29 +340,18 @@ void DisplayAstronomySection(int x, int y) {
 }
 //#########################################################################################
 void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
-  int diameter = 38;
-  double Xpos, Ypos, Rpos, Xpos1, Xpos2;//, ip, ag;
-  for (Ypos = 0; Ypos <= 45; Ypos++) {
-    Xpos = sqrt(45 * 45 - Ypos * Ypos);
-    // Draw dark part of moon
-    double pB1x = (90   - Xpos) / 90 * diameter + x;
-    double pB1y = (Ypos + 90) / 90   * diameter + y;
-    double pB2x = (Xpos + 90) / 90   * diameter + x;
-    double pB2y = (Ypos + 90) / 90   * diameter + y;
-    double pB3x = (90   - Xpos) / 90 * diameter + x;
-    double pB3y = (90   - Ypos) / 90 * diameter + y;
-    double pB4x = (Xpos + 90) / 90   * diameter + x;
-    double pB4y = (90   - Ypos) / 90 * diameter + y;
-    display.drawLine(pB1x, pB1y, pB2x, pB2y, GxEPD_BLACK);
-    display.drawLine(pB3x, pB3y, pB4x, pB4y, GxEPD_BLACK);
+  const int diameter = 38;
+  double Phase = NormalizedMoonPhase(dd, mm, yy);
+  if (hemisphere == "south") Phase = 1 - Phase;
+
+  // Draw dark part of moon
+  display.fillCircle(x + diameter - 1, y + diameter, diameter/2 + 1, GxEPD_BLACK);
+  const int number_of_lines = 90;
+  for (double Ypos = 0; Ypos <= number_of_lines/2; Ypos++) {
+    double Xpos = sqrt(number_of_lines/2 * number_of_lines/2 - Ypos * Ypos);
     // Determine the edges of the lighted part of the moon
-    int j = JulianDate(dd, mm, yy);
-    //Calculate the approximate phase of the moon
-    double Phase = (j + 4.867) / 29.53059;
-    Phase = Phase - (int)Phase;
-    //if (Phase < 0.5) ag = Phase * 29.53059 + 29.53059 / 2; else ag = Phase * 29.53059 - 29.53059 / 2; // Moon's age in days if required
-    if (hemisphere == "south") Phase = 1 - Phase;
-    Rpos = 2 * Xpos;
+    double Rpos = 2 * Xpos;
+    double Xpos1, Xpos2;
     if (Phase < 0.5) {
       Xpos1 = - Xpos;
       Xpos2 = Rpos - 2 * Phase * Rpos - Xpos;
@@ -372,16 +361,16 @@ void DrawMoon(int x, int y, int dd, int mm, int yy, String hemisphere) {
       Xpos2 = Xpos - 2 * Phase * Rpos + Rpos;
     }
     // Draw light part of moon
-    double pW1x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW1y = (90 - Ypos)  / 90 * diameter + y;
-    double pW2x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW2y = (90 - Ypos)  / 90 * diameter + y;
-    double pW3x = (Xpos1 + 90) / 90 * diameter + x;
-    double pW3y = (Ypos + 90)  / 90 * diameter + y;
-    double pW4x = (Xpos2 + 90) / 90 * diameter + x;
-    double pW4y = (Ypos + 90)  / 90 * diameter + y;
-    display.drawLine(pW1x, pW1y, pW2x, pW2y, GxEPD_WHITE);
-    display.drawLine(pW3x, pW3y, pW4x, pW4y, GxEPD_WHITE);
+    double pW1x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW1y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW2x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW2y = (number_of_lines - Ypos)  / number_of_lines * diameter + y;
+    double pW3x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;
+    double pW3y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
+    double pW4x = (Xpos2 + number_of_lines) / number_of_lines * diameter + x;
+    double pW4y = (Ypos + number_of_lines)  / number_of_lines * diameter + y;
+    display.drawLine(pW1x, pW1y, pW2x, pW2y,GxEPD_WHITE);
+    display.drawLine(pW3x, pW3y, pW4x, pW4y,GxEPD_WHITE);
   }
   display.drawCircle(x + diameter - 1, y + diameter, diameter / 2, GxEPD_BLACK);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -92,35 +92,23 @@ bool DecodeWeather(WiFiClient& json, String Type) {
 }
 //#########################################################################################
 String ConvertUnixTime(int unix_time) {
-  struct tm *now_tm;
-  int hour, min, day, month, year; // second, wday; // include if required
-  // timeval tv = {unix_time,0};
+  // Returns either '21:12  ' or ' 09:12pm' depending on Units mode
   time_t tm = unix_time;
-  now_tm = localtime(&tm);
-  hour   = now_tm->tm_hour;
-  min    = now_tm->tm_min;
-  //second = now_tm->tm_sec;
-  //wday   = now_tm->tm_wday; // Include if required
-  day    = now_tm->tm_mday;
-  month  = now_tm->tm_mon + 1;
-  year   = 1900 + now_tm->tm_year; // To get just YY information
+  struct tm *now_tm = localtime(&tm);
+  int day    = now_tm->tm_mday;
+  int month  = now_tm->tm_mon + 1;
+  int year   = 1900 + now_tm->tm_year; // To get just YY information
   MoonDay   = day;
   MoonMonth = month;
   MoonYear  = year;
+  char output[40];
   if (Units == "M") {
-    time_str =  (hour < 10 ? "0" + String(hour) : String(hour)) + ":" + (min < 10 ? "0" + String(min) : String(min)) + ":" + "  ";  // HH:MM   05/07/17
-    time_str += (day < 10 ? "0" + String(day) : String(day)) + "/" + (month < 10 ? "0" + String(month) : String(month)) + "/" + (year < 10 ? "0" + String(year) : String(year)); // HH:MM   05/07/17
+    strftime(output, sizeof(output), "%H:%M %d/%m/%y", now_tm);
   }
   else {
-    String ampm = "am";
-    if (hour > 11) ampm = "pm";
-    hour = hour % 12; if (hour == 0) hour = 12;
-    time_str =  (hour % 12 < 10 ? "0" + String(hour % 12) : String(hour % 12)) + ":" + (min < 10 ? "0" + String(min) : String(min)) + ampm + " ";      // HH:MMam 07/05/17
-    time_str += (month < 10 ? "0" + String(month) : String(month)) + "/" + (day < 10 ? "0" + String(day) : String(day)) + "/" + "/" + (year < 10 ? "0" + String(year) : String(year)); // HH:MMpm 07/05/17
+    strftime(output, sizeof(output), "%I:%M%P %m/%d/%y", now_tm);
   }
-  // Returns either '21:12  ' or ' 09:12pm' depending on Units mode
-  //Serial.println(time_str);
-  return time_str;
+  return output;
 }
 //#########################################################################################
 //WiFiClient client; // wifi client object

--- a/src/common.h
+++ b/src/common.h
@@ -95,12 +95,6 @@ String ConvertUnixTime(int unix_time) {
   // Returns either '21:12  ' or ' 09:12pm' depending on Units mode
   time_t tm = unix_time;
   struct tm *now_tm = localtime(&tm);
-  int day    = now_tm->tm_mday;
-  int month  = now_tm->tm_mon + 1;
-  int year   = 1900 + now_tm->tm_year; // To get just YY information
-  MoonDay   = day;
-  MoonMonth = month;
-  MoonYear  = year;
   char output[40];
   if (Units == "M") {
     strftime(output, sizeof(output), "%H:%M %d/%m/%y", now_tm);


### PR DESCRIPTION
* Moon phase now uses UTC day (makes up to one day offset for AU/NZ)
* ConvertUnixTime only converts timestamp to String, no side effects
* ConvertUnixTime uses strftime instead of manual formatting
* DrawMoon simplified, uses fillCircle, no more artifacts (7.5" untested; I don't have a 7.5" module so I couldn't double check the GxEPD2 version)
* Added U8g2_for_Adafruit_GFX to README

