### PR TITLE
Assign to Forecast1 and Forecast2

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -68,8 +68,8 @@ bool DecodeWeather(WiFiClient& json, String Type) {
       WxForecast[r].Pressure          = list[r]["main"]["pressure"].as<float>();          Serial.println("Pres: "+String(WxForecast[r].Pressure));
       WxForecast[r].Humidity          = list[r]["main"]["humidity"].as<float>();          Serial.println("Humi: "+String(WxForecast[r].Humidity));
       WxForecast[r].Forecast0         = list[r]["weather"][0]["main"].as<char*>();        Serial.println("For0: "+String(WxForecast[r].Forecast0));
-      WxForecast[r].Forecast0         = list[r]["weather"][1]["main"].as<char*>();        Serial.println("For1: "+String(WxForecast[r].Forecast1));
-      WxForecast[r].Forecast0         = list[r]["weather"][2]["main"].as<char*>();        Serial.println("For2: "+String(WxForecast[r].Forecast2));
+      WxForecast[r].Forecast1         = list[r]["weather"][1]["main"].as<char*>();        Serial.println("For1: "+String(WxForecast[r].Forecast1));
+      WxForecast[r].Forecast2         = list[r]["weather"][2]["main"].as<char*>();        Serial.println("For2: "+String(WxForecast[r].Forecast2));
       WxForecast[r].Icon              = list[r]["weather"][0]["icon"].as<char*>();        Serial.println("Icon: "+String(WxForecast[r].Icon));
       WxForecast[r].Description       = list[r]["weather"][0]["description"].as<char*>(); Serial.println("Desc: "+String(WxForecast[r].Description));
       WxForecast[r].Cloudcover        = list[r]["clouds"]["all"].as<int>();               Serial.println("CCov: "+String(WxForecast[r].Cloudcover)); // in % of cloud cover


### PR DESCRIPTION
Previously `WxForecast[r].Forecast0` was being set on 3 consecutive lines. This change makes it so `WxForecast[r].Forecast1` and `WxForecast[r].Forecast2` are set instead.

**Note:** I have not actually tested this change, but I was looking through the code because I am working on a similar project and I thought this might be a bug. Of course, if I have misunderstood the code please reject the PR.

**Note2:** I created this PR from the github website and it appears to have modified whitespace at the end of the file. That was unintentional but I don't know how to undo it :-)