### PR TITLE
Parse localized weather conditions and current precipitacion

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -38,8 +38,8 @@ bool DecodeWeather(WiFiClient& json, String Type) {
     WxConditions[0].lat         = root["coord"]["lat"].as<float>();              Serial.println(" Lat: "+String(WxConditions[0].lat));
     WxConditions[0].Main0       = root["weather"][0]["main"].as<char*>();        Serial.println("Main: "+String(WxConditions[0].Main0));
     WxConditions[0].Forecast0   = root["weather"][0]["description"].as<char*>(); Serial.println("For0: "+String(WxConditions[0].Forecast0));
-    WxConditions[0].Forecast1   = root["weather"][1]["main"].as<char*>();        Serial.println("For1: "+String(WxConditions[0].Forecast1));
-    WxConditions[0].Forecast2   = root["weather"][2]["main"].as<char*>();        Serial.println("For2: "+String(WxConditions[0].Forecast2));
+    WxConditions[0].Forecast1   = root["weather"][1]["description"].as<char*>(); Serial.println("For1: "+String(WxConditions[0].Forecast1));
+    WxConditions[0].Forecast2   = root["weather"][2]["description"].as<char*>(); Serial.println("For2: "+String(WxConditions[0].Forecast2));
     WxConditions[0].Icon        = root["weather"][0]["icon"].as<char*>();        Serial.println("Icon: "+String(WxConditions[0].Icon));
     WxConditions[0].Temperature = root["main"]["temp"].as<float>();              Serial.println("Temp: "+String(WxConditions[0].Temperature));
     WxConditions[0].Pressure    = root["main"]["pressure"].as<float>();          Serial.println("Pres: "+String(WxConditions[0].Pressure));
@@ -50,6 +50,8 @@ bool DecodeWeather(WiFiClient& json, String Type) {
     WxConditions[0].Winddir     = root["wind"]["deg"].as<float>();               Serial.println("WDir: "+String(WxConditions[0].Winddir));
     WxConditions[0].Cloudcover  = root["clouds"]["all"].as<int>();               Serial.println("CCov: "+String(WxConditions[0].Cloudcover)); // in % of cloud cover
     WxConditions[0].Visibility  = root["visibility"].as<int>();                  Serial.println("Visi: "+String(WxConditions[0].Visibility)); // in metres
+    WxConditions[0].Rainfall    = root["rain"]["1h"].as<float>();                Serial.println("Rain: "+String(WxConditions[0].Rainfall));
+    WxConditions[0].Snowfall    = root["snow"]["1h"].as<float>();                Serial.println("Snow: "+String(WxConditions[0].Snowfall));
     WxConditions[0].Country     = root["sys"]["country"].as<char*>();            Serial.println("Ctry: "+String(WxConditions[0].Country));
     WxConditions[0].Sunrise     = root["sys"]["sunrise"].as<int>();              Serial.println("SRis: "+String(WxConditions[0].Sunrise));
     WxConditions[0].Sunset      = root["sys"]["sunset"].as<int>();               Serial.println("SSet: "+String(WxConditions[0].Sunset));


### PR DESCRIPTION
Hello,

I noticed today, that display was showing the second weather condition in english instead of localized string. In my case in czech language.

The response from server in that case looked like this:

```
{
  "coord": {
    "lon": 14.41,
    "lat": 50.01
  },
  "weather": [
    {
      "id": 310,
      "main": "Drizzle",
      "description": "slabé mrholení a déšť",
      "icon": "09n"
    },
    {
      "id": 701,
      "main": "Mist",
      "description": "mlha",
      "icon": "50n"
    }
  ],
  "base": "stations",
  "main": {
    "temp": 9.06,
    "pressure": 1008,
    "humidity": 93,
    "temp_min": 7.78,
    "temp_max": 10
  },
  "visibility": 5000,
  "wind": {
    "speed": 3.1,
    "deg": 90
  },
  "clouds": {
    "all": 90
  },
  "dt": 1574353822,
  "sys": {
    "type": 1,
    "id": 6848,
    "country": "CZ",
    "sunrise": 1574317449,
    "sunset": 1574349146
  },
  "timezone": 3600,
  "id": 3070420,
  "name": "Modrany",
  "cod": 200
}
```
This pull request will fix this problem. So, the localized weather condition will be parsed.

I also added parsing of current (1h) precipitacion.