### PR TITLE
Add "DebugDisplayUpdate" variable for instant update

### DIFF
--- a/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
+++ b/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
@@ -112,7 +112,7 @@ void setup() {
   StartTime = millis();
   Serial.begin(115200);
   if (StartWiFi() == WL_CONNECTED && SetupTime() == true) {
-    if ((CurrentHour >= WakeupTime && CurrentHour <= SleepTime)) {
+    if ((CurrentHour >= WakeupTime && CurrentHour <= SleepTime) || DebugDisplayUpdate) {
       InitialiseDisplay(); // Give screen time to initialise by getting weather data!
       byte Attempts = 1;
       bool RxWeather = false, RxForecast = false;


### PR DESCRIPTION
Add "DebugDisplayUpdate" boolean in the condition line 115 in order to get an update if we are in development mode or if we would like an instant refresh when the microcontroller is powered on the first time.

"DebugDisplayUpdate" will be defined in "owm_credentials.h" file.