### PR TITLE
Platformio support

### DIFF
--- a/examples/M5_CoreInk/platformio.ini
+++ b/examples/M5_CoreInk/platformio.ini
@@ -1,4 +1,6 @@
 [platformio]
+default_envs = m5stack-coreink
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/M5_CoreInk/platformio.ini
+++ b/examples/M5_CoreInk/platformio.ini
@@ -1,0 +1,8 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+lib_deps = 
+    lib_deps = ${GxEPD2.lib_deps}
+    https://github.com/m5stack/M5-CoreInk
+

--- a/examples/OWM_75_epaper_v16_7/platformio.ini
+++ b/examples/OWM_75_epaper_v16_7/platformio.ini
@@ -1,6 +1,11 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]
     lib_deps = ${GxEPD2.lib_deps}
+
 

--- a/examples/OWM_75_epaper_v16_7/platformio.ini
+++ b/examples/OWM_75_epaper_v16_7/platformio.ini
@@ -1,0 +1,6 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+

--- a/examples/Waveshare_1_54/platformio.ini
+++ b/examples/Waveshare_1_54/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_1_54/platformio.ini
+++ b/examples/Waveshare_1_54/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_2_13_T5/platformio.ini
+++ b/examples/Waveshare_2_13_T5/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_2_13_T5/platformio.ini
+++ b/examples/Waveshare_2_13_T5/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_2_7/platformio.ini
+++ b/examples/Waveshare_2_7/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_2_7/platformio.ini
+++ b/examples/Waveshare_2_7/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_2_9/platformio.ini
+++ b/examples/Waveshare_2_9/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_2_9/platformio.ini
+++ b/examples/Waveshare_2_9/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_2_9_T5/platformio.ini
+++ b/examples/Waveshare_2_9_T5/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_2_9_T5/platformio.ini
+++ b/examples/Waveshare_2_9_T5/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_4_2/platformio.ini
+++ b/examples/Waveshare_4_2/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_4_2/platformio.ini
+++ b/examples/Waveshare_4_2/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_7_5/platformio.ini
+++ b/examples/Waveshare_7_5/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_7_5/platformio.ini
+++ b/examples/Waveshare_7_5/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_7_5_T7/platformio.ini
+++ b/examples/Waveshare_7_5_T7/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_7_5_T7/platformio.ini
+++ b/examples/Waveshare_7_5_T7/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/Waveshare_9_7/platformio.ini
+++ b/examples/Waveshare_9_7/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs = ../platformio.inc
+
+[gfxlib]
+    lib_deps = ${GxEPD2.lib_deps}
+
+

--- a/examples/Waveshare_9_7/platformio.ini
+++ b/examples/Waveshare_9_7/platformio.ini
@@ -1,4 +1,8 @@
 [platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
 extra_configs = ../platformio.inc
 
 [gfxlib]

--- a/examples/platformio.inc
+++ b/examples/platformio.inc
@@ -1,0 +1,57 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+; esp32dev works for the majority of ESP32 based dev boards, change this 
+; for your board if desired
+default_envs = esp32dev
+src_dir = .
+
+[common]
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    ArduinoJson
+    Wire
+    HTTPClient
+    WiFiClientSecure
+    Adafruit BusIO
+
+[MiniGrafx]
+lib_deps = 
+    Mini Grafx
+    FS
+    SPIFFS
+
+[GxEPD2]
+lib_deps = 
+    GxEPD2
+    U8g2_for_Adafruit_GFX
+
+
+[base:esp32]
+lib_extra_dirs = ../..
+platform = espressif32
+framework = ${common.framework}
+lib_deps = ${common.lib_deps} ${gfxlib.lib_deps}
+
+[env:esp32dev]
+board = esp32dev
+extends = base:esp32
+
+[env:esp32doit-devkit-v1]
+board = esp32doit-devkit-v1
+extends = base:esp32
+
+[env:lolin_d32_pro]
+board = lolin_d32_pro
+extends = base:esp32
+
+

--- a/examples/platformio.inc
+++ b/examples/platformio.inc
@@ -8,12 +8,6 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[platformio]
-; esp32dev works for the majority of ESP32 based dev boards, change this 
-; for your board if desired
-default_envs = esp32dev
-src_dir = .
-
 [common]
 framework = arduino
 monitor_speed = 115200
@@ -54,4 +48,7 @@ extends = base:esp32
 board = lolin_d32_pro
 extends = base:esp32
 
+[env:m5stack-coreink]
+extends = base:esp32
+board = m5stack-coreink
 


### PR DESCRIPTION
This PR adds support for building using platformio.  

To build cd into the desired example subdirectory and run ``pio run``.

Only the Waveshare_7_5_T7 example has been tested on hardware, but all examples build.


