### PR TITLE
patch calculation of sleep duration

### DIFF
--- a/examples/Waveshare_4_2/Waveshare_4_2.ino
+++ b/examples/Waveshare_4_2/Waveshare_4_2.ino
@@ -136,8 +136,12 @@ void loop() { // this will never run!
 //#########################################################################################
 void BeginSleep() {
   display.powerOff();
-  long SleepTimer = (SleepDuration * 60 - ((CurrentMin % SleepDuration) * 60 + CurrentSec)); //Some ESP32 are too fast to maintain accurate time
-  esp_sleep_enable_timer_wakeup((SleepTimer+20) * 1000000LL); // Added +20 seconnds to cover ESP32 RTC timer source inaccuracies
+  long SleepTimer = SleepDuration * 60; // theoretical sleep duration
+  long offset = (CurrentMin % SleepDuration) * 60 + CurrentSec; // number of seconds elapsed after last theoretical wake-up time point
+  if (offset > SleepDuration/2 * 60){ // waking up too early will cause <offset> too large
+    offset -= SleepDuration * 60; // then we should make it negative, so as to extend this coming sleep duration
+  }
+  esp_sleep_enable_timer_wakeup((SleepTimer - offset) * 1000000LL); // do compensation to cover ESP32 RTC timer source inaccuracies
 #ifdef BUILTIN_LED
   pinMode(BUILTIN_LED, INPUT); // If it's On, turn it off and some boards use GPIO-5 for SPI-SS, which remains low after screen use
   digitalWrite(BUILTIN_LED, HIGH);


### PR DESCRIPTION
ESP32 will wake up too early if its RTC runs too fast, which causes extra wake-ups. For example, if it wakes up at 12:29:20, the sleep duration will be 40 seconds and ESP32 will wake up again soon, which results in extra battery consumption. With this patch, waking up at 12:29:20 will result in a sleep duration of 1800+40 seconds. This ensures only one wake-up every 30 minutes.