### PR TITLE
Update Waveshare_7_5_T7.ino

### DIFF
--- a/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
+++ b/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
@@ -563,7 +563,7 @@ boolean UpdateLocalTime() {
 //#########################################################################################
 void DrawBattery(int x, int y) {
   uint8_t percentage = 100;
-  float voltage = analogRead(35) / 4096.0 * 7.46;
+  float voltage = (float)analogReadMilliVolts(35) / 1000. * 2.;
   if (voltage > 1 ) { // Only display if there is a valid reading
     Serial.println("Voltage = " + String(voltage));
     percentage = 2836.9625 * pow(voltage, 4) - 43987.4889 * pow(voltage, 3) + 255233.8134 * pow(voltage, 2) - 656689.7123 * voltage + 632041.7303;


### PR DESCRIPTION
Make analog read function return voltage instead of raw ADC data, so as to achieve compatibility across ESP32 series.