### PR TITLE
bulk-fix out of bounds fencepost error re: issue #199

### DIFF
--- a/examples/M5_CoreInk/M5_CoreInk.ino
+++ b/examples/M5_CoreInk/M5_CoreInk.ino
@@ -191,7 +191,7 @@ void DisplayForecastSection(int x, int y) {
   DisplayForecastWeather(x + offset * 1, y, offset, 1);
   DisplayForecastWeather(x + offset * 2, y, offset, 2);
   DisplayForecastWeather(x + offset * 3, y, offset, 3);
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;
     else              pressure_readings[r] = WxForecast[r].Pressure;
@@ -199,7 +199,7 @@ void DisplayForecastSection(int x, int y) {
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701;
     else              rain_readings[r]     = WxForecast[r].Rainfall;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
 }
 //#########################################################################################
 void DisplayForecastWeather(int x, int y, int offset, int index) {

--- a/examples/OWM_75_epaper_v16_7/OWM_75_epaper_v16_7.ino
+++ b/examples/OWM_75_epaper_v16_7/OWM_75_epaper_v16_7.ino
@@ -391,7 +391,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -399,7 +399,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 120, gheight = 58;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 300;

--- a/examples/Waveshare_1_54/Waveshare_1_54.ino
+++ b/examples/Waveshare_1_54/Waveshare_1_54.ino
@@ -193,7 +193,7 @@ void DisplayForecastSection(int x, int y) {
   DisplayForecastWeather(x + offset * 1, y, offset, 1);
   DisplayForecastWeather(x + offset * 2, y, offset, 2);
   DisplayForecastWeather(x + offset * 3, y, offset, 3);
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;
     else              pressure_readings[r] = WxForecast[r].Pressure;
@@ -201,7 +201,7 @@ void DisplayForecastSection(int x, int y) {
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701;
     else              rain_readings[r]     = WxForecast[r].Rainfall;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
 }
 //#########################################################################################
 void DisplayForecastWeather(int x, int y, int offset, int index) {

--- a/examples/Waveshare_3_7/Waveshare_3_7.ino
+++ b/examples/Waveshare_3_7/Waveshare_3_7.ino
@@ -285,7 +285,7 @@ void DrawForecastSection(int x, int y) {
   DrawForecastWeather(x + 80*5, y, 5);
 
   //Long range 3day trend graphs
-  for (int r = 1; r < max_readings; r++) {
+  for (int r = 0; r < max_readings; r++) {
     if (Units == "I") {
       pressure_readings[r] = WxForecast[r].Pressure * 0.02953;
       rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701;

--- a/examples/Waveshare_4_2/Waveshare_4_2.ino
+++ b/examples/Waveshare_4_2/Waveshare_4_2.ino
@@ -191,7 +191,7 @@ void DrawForecastSection(int x, int y) {
   DrawForecastWeather(x + 56, y, 1);
   DrawForecastWeather(x + 112, y, 2);
   //       (x,y,width,height,MinValue, MaxValue, Title, Data Array, AutoScale, ChartMode)
-  for (int r = 1; r <= max_readings; r++) {
+  for (int r = 0; r < max_readings; r++) {
     if (Units == "I") {
       pressure_readings[r] = WxForecast[r].Pressure * 0.02953;
       rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701;

--- a/examples/Waveshare_7_5/Waveshare_7_5.ino
+++ b/examples/Waveshare_7_5/Waveshare_7_5.ino
@@ -397,7 +397,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -405,7 +405,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 120, gheight = 58;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 300;

--- a/examples/Waveshare_7_5_3C.ino
+++ b/examples/Waveshare_7_5_3C.ino
@@ -393,7 +393,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -401,7 +401,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 150, gheight = 72;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 375;

--- a/examples/Waveshare_7_5_3C/Waveshare_7_5_3C.ino
+++ b/examples/Waveshare_7_5_3C/Waveshare_7_5_3C.ino
@@ -393,7 +393,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -401,7 +401,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 150, gheight = 72;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 375;

--- a/examples/Waveshare_7_5_News/Waveshare_7_5_News.ino
+++ b/examples/Waveshare_7_5_News/Waveshare_7_5_News.ino
@@ -413,7 +413,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -421,7 +421,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 120, gheight = 58;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 300;

--- a/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
+++ b/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
@@ -390,7 +390,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -398,7 +398,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   int gwidth = 150, gheight = 72;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 5;
   int gy = 375;

--- a/examples/Waveshare_9_7/Waveshare_9_7.ino
+++ b/examples/Waveshare_9_7/Waveshare_9_7.ino
@@ -481,7 +481,7 @@ void DisplayForecastSection(int x, int y) {
     f++;
   } while (f <= 7);
   // Pre-load temporary arrays with with data - because C parses by reference
-  int r = 1;
+  int r = 0;
   do {
     if (Units == "I") pressure_readings[r] = WxForecast[r].Pressure * 0.02953;   else pressure_readings[r] = WxForecast[r].Pressure;
     if (Units == "I") rain_readings[r]     = WxForecast[r].Rainfall * 0.0393701; else rain_readings[r]     = WxForecast[r].Rainfall;
@@ -489,7 +489,7 @@ void DisplayForecastSection(int x, int y) {
     temperature_readings[r] = WxForecast[r].Temperature;
     humidity_readings[r]    = WxForecast[r].Humidity;
     r++;
-  } while (r <= max_readings);
+  } while (r < max_readings);
   
   int gwidth = 230, gheight = 150;
   int gx = (SCREEN_WIDTH - gwidth * 4) / 5 + 7;


### PR DESCRIPTION
This fix addresses the memory access errors raised in https://github.com/G6EJD/ESP32-e-Paper-Weather-Display/issues/199

This fix is composed of several bulk find-and-replace searches. I am unable to test any versions of the code besides examples/Waveshare_7_5_3C/Waveshare_7_5_3C.ino myself, but it appears to be  substantially similar in each case.

This fix does not address graphical issues raised in https://github.com/G6EJD/ESP32-e-Paper-Weather-Display/issues/199