### PR TITLE
 Add RHS y-axis functionality to DrawGraph(). Implement for precipitation forecast

### DIFF
--- a/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
+++ b/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
@@ -413,7 +413,7 @@ void DisplayForecastSection(int x, int y) {
   // (x,y,width,height,MinValue, MaxValue, Title, Data Array, AutoScale, ChartMode)
   DrawGraph(gx + 0 * gap, gy, gwidth, gheight, 900, 1050, Units == "M" ? TXT_PRESSURE_HPA : TXT_PRESSURE_IN, pressure_readings, max_readings, autoscale_on, barchart_off, lhs_yaxis);
   DrawGraph(gx + 1 * gap, gy, gwidth, gheight, 10, 30,    Units == "M" ? TXT_TEMPERATURE_C : TXT_TEMPERATURE_F, temperature_readings, max_readings, autoscale_on, barchart_off, lhs_yaxis);
-  DrawGraph(gx + 2 * gap, gy, gwidth, gheight, 0, 100,   TXT_HUMIDITY_PERCENT, humidity_readings, max_readings, autoscale_on, barchart_off, lhs_yaxis);
+  DrawGraph(gx + 2 * gap, gy, gwidth, gheight, 0, 100,   TXT_HUMIDITY_PERCENT, humidity_readings, max_readings, autoscale_off, barchart_off, lhs_yaxis);
   const int Rain_array_size = sizeof(rain_readings) / sizeof(float);
   const int Snow_array_size = sizeof(snow_readings) / sizeof(float);
   if (SumOfPrecip(rain_readings, Rain_array_size) >= SumOfPrecip(snow_readings, Snow_array_size)) {


### PR DESCRIPTION
 1. Add RHS y-axis labels option to Drawgraph().   
2. Plot prob of precip (pop) on precip forecast graph

The idea is to add an extra input to DrawGraph(), which specifies whether the y-axis in on the RHS or LHS of the plot.
(This variable is a boolean whereby True --> LHS axis and False --> RHS axis)

This is used to display probability of precipitation as a line plot on top of the precipitation bar chart.

(Presently only implemented in Waveshare_7_5_T7.ino, will look at copying to other 7 inch displays. Hence draft PR)

**Edit**: Realised that I can not test the port to other display sizes as I only have access to the 7.5" 800x480 E-Paper Layout. Hence only propose edits for `Waveshare_7_5_T7.ino` and will not propose edits for other screen sizes.


![image](https://github.com/G6EJD/ESP32-e-Paper-Weather-Display/assets/22616872/1ce04c73-6694-4ba1-a2a3-c3656bb51a4f)
Lefthand y-axis: mm.
Righthand y-axis: % probability of precipitation.