### PR TITLE
Waveshare_7_5_T7: Fix case "PoP"

### DIFF
--- a/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
+++ b/examples/Waveshare_7_5_T7/Waveshare_7_5_T7.ino
@@ -280,8 +280,8 @@ void DisplayPrecipitationSection(int x, int y, int pwidth, int pdepth) {
   }
   if (WxForecast[1].Snowfall >= 0.005)  // Ignore small amounts
     drawString(x - 25, y + 71, String(WxForecast[1].Snowfall, 2) + (Units == "M" ? "mm" : "in") + " **", LEFT); // Only display snowfall total today if > 0
-  if (WxForecast[1].Pop >= 0.005)       // Ignore small amounts
-    drawString(x + 2, y + 81, String(WxForecast[1].Pop*100, 0) + "%", LEFT); // Only display pop if > 0
+  if (WxForecast[1].PoP >= 0.005)       // Ignore small amounts
+    drawString(x + 2, y + 81, String(WxForecast[1].PoP*100, 0) + "%", LEFT); // Only display pop if > 0
 }
 //#########################################################################################
 void DisplayAstronomySection(int x, int y) {


### PR DESCRIPTION
Fixing a casing issue of "PoP" in examples/Waveshare_7_5_T7